### PR TITLE
Allow backgroundColor setter for views from Nib

### DIFF
--- a/DVColorLockView.swift
+++ b/DVColorLockView.swift
@@ -13,7 +13,7 @@ import UIKit
 // Highlighting a UITableViewCell won't change the color of its DVColorLockView subviews.
 // (Highlighting a UITableViewCell changes the background color of all subviews, it's annoying.)
 class DVColorLockView:UIView {
-    
+
     var lockedBackgroundColor:UIColor {
         set {
             super.backgroundColor = newValue
@@ -25,10 +25,28 @@ class DVColorLockView:UIView {
     
     override var backgroundColor:UIColor? {
         set {
+			if !locked {
+				lockedBackgroundColor = newValue
+			}
         }
         get {
             return super.backgroundColor
         }
     }
+
+	// MARK: Loading from NIB
+
+    // Disallow/allow changing the backgroundColor by it's setter
+    private var locked: Bool = true
     
+	required init?(coder aDecoder: NSCoder) {
+		locked = false
+		super.init(coder: aDecoder)
+	}
+
+	override func awakeFromNib() {
+		super.awakeFromNib()
+		locked = true
+	}
+
 }


### PR DESCRIPTION
DVColorLockView is not working for views, configured in _.xib_ or _.storyboard_ file.
This update allow the use of a backgroundColor setter for such views.
